### PR TITLE
fix: preserve constraint index maps in remove_inactive_constraints

### DIFF
--- a/include/eqlib/Problem.h
+++ b/include/eqlib/Problem.h
@@ -932,11 +932,11 @@ public: // methods
             max_element_n = std::max(max_element_n, m_elements_g[i]->nb_variables());
             max_element_m = std::max(max_element_m, m_elements_g[i]->nb_equations());
 
-            element_g_nb_variables[j] = element_g_nb_variables[i];
+            element_g_nb_variables[j] = m_element_g_nb_variables[i];
 
-            element_g_nb_equations[j] = element_g_nb_equations[i];
-            element_g_variable_indices[j] = std::move(element_g_variable_indices[i]);
-            element_g_equation_indices[j] = std::move(element_g_equation_indices[i]);
+            element_g_nb_equations[j] = m_element_g_nb_equations[i];
+            element_g_variable_indices[j] = std::move(m_element_g_variable_indices[i]);
+            element_g_equation_indices[j] = std::move(m_element_g_equation_indices[i]);
 
             elements_g[j] = std::move(m_elements_g[i]);
 

--- a/tests/test_remove_inactive_constraints.py
+++ b/tests/test_remove_inactive_constraints.py
@@ -1,0 +1,93 @@
+import eqlib as eq
+import numpy as np
+import pytest
+from numpy.testing import assert_almost_equal
+
+if __name__ == "__main__":
+    import os
+    import sys
+
+    print(f"pid: {os.getpid()}")
+    pytest.main(sys.argv)
+
+
+class ConstantObjective(eq.Objective):
+    def __init__(self, variables, f, g, h):
+        eq.Objective.__init__(self)
+        self.variables = variables
+        self._f = f
+        self._g = g
+        self._h = h
+
+    def compute(self, g, h):
+        if len(g) != 0:
+            g[:] = self._g
+        if len(h) != 0:
+            h[:] = self._h
+        return self._f
+
+
+class ConstantConstraint(eq.Constraint):
+    def __init__(self, equations, variables, fs, gs, hs):
+        eq.Constraint.__init__(self)
+        self.equations = equations
+        self.variables = variables
+        self._fs = fs
+        self._gs = gs
+        self._hs = hs
+
+    def compute(self, fs, gs, hs):
+        for k in range(len(fs)):
+            fs[k] = self._fs[k]
+            if len(gs[k]) != 0:
+                gs[k][:] = self._gs[k]
+            if len(hs[k]) != 0:
+                hs[k][:] = self._hs[k]
+
+
+@pytest.fixture
+def problem():
+    g1 = eq.Equation(name="g1", lower_bound=1, upper_bound=1, multiplier=2.0)
+
+    x1 = eq.Variable(name="x1", value=2.0)
+    x2 = eq.Variable(name="x2", value=3.0)
+
+    objectives = [
+        ConstantObjective([x1, x2], 1.0, [2.0, 3.0], [[4.0, 0.0], [0.0, 5.0]])
+    ]
+    constraints = [
+        ConstantConstraint(
+            [g1], [x1, x2], [10.0], [[2.0, 3.0]], [[[6.0, 0.0], [0.0, 0.0]]]
+        )
+    ]
+
+    return eq.Problem(objectives, constraints)
+
+
+def test_remove_inactive_elements_preserves_active_constraints(problem):
+    """When every element is active, ``remove_inactive_elements`` must be a
+    no-op: the assembled ``g``/``dg``/``hm`` must be identical before and after.
+
+    A copy-paste defect in ``remove_inactive_constraints`` used to reset the
+    per-element equation/variable index maps to empty, silently dropping every
+    constraint's contribution from ``g`` and ``dg`` after the call.
+    """
+    problem.compute()
+
+    g_before = problem.g.copy()
+    dg_before = problem.dg.toarray()
+    hm_before = problem.hm.toarray()
+    df_before = problem.df.copy()
+
+    # Guard against a vacuous test: the constraint must actually contribute.
+    assert np.any(g_before != 0.0)
+    assert np.any(dg_before != 0.0)
+
+    problem.remove_inactive_elements()
+
+    problem.compute()
+
+    assert_almost_equal(problem.g, g_before)
+    assert_almost_equal(problem.dg.toarray(), dg_before)
+    assert_almost_equal(problem.hm.toarray(), hm_before)
+    assert_almost_equal(problem.df, df_before)


### PR DESCRIPTION
## Problem

`Problem::remove_inactive_constraints()` rebuilt the per-element constraint bookkeeping by reading from the **freshly-allocated, empty local vectors** instead of the members `m_element_g_*`:

```cpp
element_g_nb_variables[j] = element_g_nb_variables[i];   // local (empty), not m_element_g_nb_variables[i]
element_g_nb_equations[j] = element_g_nb_equations[i];
element_g_variable_indices[j] = std::move(element_g_variable_indices[i]);
element_g_equation_indices[j] = std::move(element_g_equation_indices[i]);
```

This silently reset every constraint's equation/variable index maps and counts to empty. After `remove_inactive_elements()`, `compute_element_g` hits its `variable_indices.empty()` early-return, so **all constraint contributions disappear from `g`, `dg` and `hm`** — even when every constraint is active (then `j == i`, but the read still targets the empty local slot).

The objective counterpart `remove_inactive_objectives()` reads the members correctly; this was a copy-paste divergence.

## Fix

Read from `m_element_g_*`, mirroring `remove_inactive_objectives()`.

## Test

New `tests/test_remove_inactive_constraints.py` builds a problem with an active objective + active constraint (pure-Python elements, no HyperJet dependency) and asserts that `remove_inactive_elements()` is a no-op when all elements are active: `g`, `dg`, `hm` and `df` are identical before and after.

- Before the fix: the constraint residual drops from `10` to `0` after the call (test fails).
- After the fix: values are preserved; full suite passes (44 passed).