### PR TITLE
fix: accumulate gradient/Hessian over integration points in AD objectives

### DIFF
--- a/include/eqlib/objectives/IgaNormalDistanceAD.h
+++ b/include/eqlib/objectives/IgaNormalDistanceAD.h
@@ -63,6 +63,14 @@ public: // methods
 
         double f = 0;
 
+        if constexpr (TOrder > 0) {
+            g.setZero();
+        }
+
+        if constexpr (TOrder > 1) {
+            h.setZero();
+        }
+
         for (const auto& [shape_functions_a, shape_functions_b, weight] : m_data) {
             const auto a1_a = Space::template variables<0, 3>(evaluate_act_geometry(m_nodes_a, shape_functions_a.row(1)));
             const auto a2_a = Space::template variables<3, 3>(evaluate_act_geometry(m_nodes_a, shape_functions_a.row(2)));
@@ -85,14 +93,14 @@ public: // methods
                     const index rd = r % 3;
                     const index ri = r / 3;
 
-                    g(0 + r) = result.g(0 + rd) * shape_functions_a(1, ri) + result.g(3 + rd) * shape_functions_a(2, ri);
+                    g(0 + r) += result.g(0 + rd) * shape_functions_a(1, ri) + result.g(3 + rd) * shape_functions_a(2, ri);
                 }
 
                 for (index r = 0; r < b; r++) {
                     const index rd = r % 3;
                     const index ri = r / 3;
 
-                    g(a + r) = result.g(6 + rd) * shape_functions_b(1, ri) + result.g(9 + rd) * shape_functions_b(2, ri);
+                    g(a + r) += result.g(6 + rd) * shape_functions_b(1, ri) + result.g(9 + rd) * shape_functions_b(2, ri);
                 }
             }
 
@@ -105,7 +113,7 @@ public: // methods
                         const index sd = s % 3;
                         const index si = s / 3;
 
-                        h(0 + r, 0 + s) = result.h(0 + rd, 0 + sd) * shape_functions_a(1, ri) * shape_functions_a(1, si)
+                        h(0 + r, 0 + s) += result.h(0 + rd, 0 + sd) * shape_functions_a(1, ri) * shape_functions_a(1, si)
                             + result.h(3 + rd, 0 + sd) * shape_functions_a(2, ri) * shape_functions_a(1, si)
                             + result.h(0 + rd, 3 + sd) * shape_functions_a(1, ri) * shape_functions_a(2, si)
                             + result.h(3 + rd, 3 + sd) * shape_functions_a(2, ri) * shape_functions_a(2, si);
@@ -115,7 +123,7 @@ public: // methods
                         const index sd = s % 3;
                         const index si = s / 3;
 
-                        h(0 + r, a + s) = result.h(0 + rd, 6 + sd) * shape_functions_a(1, ri) * shape_functions_b(1, si)
+                        h(0 + r, a + s) += result.h(0 + rd, 6 + sd) * shape_functions_a(1, ri) * shape_functions_b(1, si)
                             + result.h(3 + rd, 6 + sd) * shape_functions_a(2, ri) * shape_functions_b(1, si)
                             + result.h(0 + rd, 9 + sd) * shape_functions_a(1, ri) * shape_functions_b(2, si)
                             + result.h(3 + rd, 9 + sd) * shape_functions_a(2, ri) * shape_functions_b(2, si);
@@ -130,7 +138,7 @@ public: // methods
                         const index sd = s % 3;
                         const index si = s / 3;
 
-                        h(a + r, a + s) = result.h(6 + rd, 6 + sd) * shape_functions_b(1, ri) * shape_functions_b(1, si)
+                        h(a + r, a + s) += result.h(6 + rd, 6 + sd) * shape_functions_b(1, ri) * shape_functions_b(1, si)
                             + result.h(9 + rd, 6 + sd) * shape_functions_b(2, ri) * shape_functions_b(1, si)
                             + result.h(6 + rd, 9 + sd) * shape_functions_b(1, ri) * shape_functions_b(2, si)
                             + result.h(9 + rd, 9 + sd) * shape_functions_b(2, ri) * shape_functions_b(2, si);

--- a/include/eqlib/objectives/IgaPointDistanceAD.h
+++ b/include/eqlib/objectives/IgaPointDistanceAD.h
@@ -89,14 +89,14 @@ public: // methods
                     const index rd = r % 3;
                     const index ri = r / 3;
 
-                    g(0 + r) = result.g(0 + rd) * shape_functions_a(0, ri);
+                    g(0 + r) += result.g(0 + rd) * shape_functions_a(0, ri);
                 }
 
                 for (index r = 0; r < b; r++) {
                     const index rd = r % 3;
                     const index ri = r / 3;
 
-                    g(a + r) = result.g(3 + rd) * shape_functions_b(0, ri);
+                    g(a + r) += result.g(3 + rd) * shape_functions_b(0, ri);
                 }
             }
 
@@ -113,7 +113,7 @@ public: // methods
                             continue;
                         }
 
-                        h(0 + r, 0 + s) = result.h(0 + rd, 0 + sd) * shape_functions_a(0, ri) * shape_functions_a(0, si);
+                        h(0 + r, 0 + s) += result.h(0 + rd, 0 + sd) * shape_functions_a(0, ri) * shape_functions_a(0, si);
                     }
 
                     for (index s = 0; s < b; s++) {
@@ -124,7 +124,7 @@ public: // methods
                             continue;
                         }
 
-                        h(0 + r, a + s) = result.h(0 + rd, 3 + sd) * shape_functions_a(0, ri) * shape_functions_b(0, si);
+                        h(0 + r, a + s) += result.h(0 + rd, 3 + sd) * shape_functions_a(0, ri) * shape_functions_b(0, si);
                     }
                 }
 
@@ -140,7 +140,7 @@ public: // methods
                             continue;
                         }
 
-                        h(a + r, a + s) = result.h(3 + rd, 3 + sd) * shape_functions_b(0, ri) * shape_functions_b(0, si);
+                        h(a + r, a + s) += result.h(3 + rd, 3 + sd) * shape_functions_b(0, ri) * shape_functions_b(0, si);
                     }
                 }
             }

--- a/include/eqlib/objectives/IgaRotationCouplingAD.h
+++ b/include/eqlib/objectives/IgaRotationCouplingAD.h
@@ -80,6 +80,14 @@ public: // methods
 
         double f = 0;
 
+        if constexpr (TOrder > 0) {
+            g.setZero();
+        }
+
+        if constexpr (TOrder > 1) {
+            h.setZero();
+        }
+
         for (const auto& [shape_functions_a, shape_functions_b, ref_a3_a, ref_a3_b, axis, weight] : m_data) {
             const auto a1_a = Space::template variables<0, 3>(evaluate_act_geometry(m_nodes_a, shape_functions_a.row(1)));
             const auto a2_a = Space::template variables<3, 3>(evaluate_act_geometry(m_nodes_a, shape_functions_a.row(2)));
@@ -111,14 +119,14 @@ public: // methods
                     const index rd = r % 3;
                     const index ri = r / 3;
 
-                    g(0 + r) = result.g(0 + rd) * shape_functions_a(1, ri) + result.g(3 + rd) * shape_functions_a(2, ri);
+                    g(0 + r) += result.g(0 + rd) * shape_functions_a(1, ri) + result.g(3 + rd) * shape_functions_a(2, ri);
                 }
 
                 for (index r = 0; r < b; r++) {
                     const index rd = r % 3;
                     const index ri = r / 3;
 
-                    g(a + r) = result.g(6 + rd) * shape_functions_b(1, ri) + result.g(9 + rd) * shape_functions_b(2, ri);
+                    g(a + r) += result.g(6 + rd) * shape_functions_b(1, ri) + result.g(9 + rd) * shape_functions_b(2, ri);
                 }
             }
 
@@ -131,7 +139,7 @@ public: // methods
                         const index sd = s % 3;
                         const index si = s / 3;
 
-                        h(0 + r, 0 + s) = result.h(0 + rd, 0 + sd) * shape_functions_a(1, ri) * shape_functions_a(1, si)
+                        h(0 + r, 0 + s) += result.h(0 + rd, 0 + sd) * shape_functions_a(1, ri) * shape_functions_a(1, si)
                             + result.h(3 + rd, 0 + sd) * shape_functions_a(2, ri) * shape_functions_a(1, si)
                             + result.h(0 + rd, 3 + sd) * shape_functions_a(1, ri) * shape_functions_a(2, si)
                             + result.h(3 + rd, 3 + sd) * shape_functions_a(2, ri) * shape_functions_a(2, si);
@@ -141,7 +149,7 @@ public: // methods
                         const index sd = s % 3;
                         const index si = s / 3;
 
-                        h(0 + r, a + s) = result.h(0 + rd, 6 + sd) * shape_functions_a(1, ri) * shape_functions_b(1, si)
+                        h(0 + r, a + s) += result.h(0 + rd, 6 + sd) * shape_functions_a(1, ri) * shape_functions_b(1, si)
                             + result.h(3 + rd, 6 + sd) * shape_functions_a(2, ri) * shape_functions_b(1, si)
                             + result.h(0 + rd, 9 + sd) * shape_functions_a(1, ri) * shape_functions_b(2, si)
                             + result.h(3 + rd, 9 + sd) * shape_functions_a(2, ri) * shape_functions_b(2, si);
@@ -156,7 +164,7 @@ public: // methods
                         const index sd = s % 3;
                         const index si = s / 3;
 
-                        h(a + r, 0 + s) = result.h(6 + rd, 0 + sd) * shape_functions_b(1, ri) * shape_functions_a(1, si)
+                        h(a + r, 0 + s) += result.h(6 + rd, 0 + sd) * shape_functions_b(1, ri) * shape_functions_a(1, si)
                             + result.h(9 + rd, 0 + sd) * shape_functions_b(2, ri) * shape_functions_a(1, si)
                             + result.h(6 + rd, 3 + sd) * shape_functions_b(1, ri) * shape_functions_a(2, si)
                             + result.h(9 + rd, 3 + sd) * shape_functions_b(2, ri) * shape_functions_a(2, si);
@@ -166,7 +174,7 @@ public: // methods
                         const index sd = s % 3;
                         const index si = s / 3;
 
-                        h(a + r, a + s) = result.h(6 + rd, 6 + sd) * shape_functions_b(1, ri) * shape_functions_b(1, si)
+                        h(a + r, a + s) += result.h(6 + rd, 6 + sd) * shape_functions_b(1, ri) * shape_functions_b(1, si)
                             + result.h(9 + rd, 6 + sd) * shape_functions_b(2, ri) * shape_functions_b(1, si)
                             + result.h(6 + rd, 9 + sd) * shape_functions_b(1, ri) * shape_functions_b(2, si)
                             + result.h(9 + rd, 9 + sd) * shape_functions_b(2, ri) * shape_functions_b(2, si);

--- a/tests/test_iga_ad_multi_point.py
+++ b/tests/test_iga_ad_multi_point.py
@@ -1,0 +1,112 @@
+"""Multiple integration points per AD objective must accumulate.
+
+Each ``Iga*AD`` objective can hold several integration points (repeated
+``add()`` calls). The assembled gradient ``g`` and Hessian ``h`` of an element
+with N points must equal the sum of the contributions of N single-point
+elements over the same nodes -- exactly as the scalar value ``f`` does.
+
+The AD objectives used to write ``g``/``h`` with ``=`` inside the loop over the
+integration points, so only the *last* point survived in ``g``/``h`` while
+``f`` was summed over all points.
+"""
+
+import eqlib as eq
+import numpy as np
+import pytest
+from numpy.testing import assert_almost_equal
+
+if __name__ == "__main__":
+    import os
+    import sys
+
+    print(f"pid: {os.getpid()}")
+    pytest.main(sys.argv)
+
+
+REF_A = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+ACT_A = [[0.0, 0.0, 0.05], [1.1, 0.0, 0.1], [0.0, 1.05, 0.2]]
+REF_B = [[0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [0.0, 1.0, 1.0]]
+ACT_B = [[0.02, 0.0, 1.0], [1.0, 0.03, 1.1], [0.0, 1.0, 0.95]]
+
+# 3-row shape functions (values, d/du, d/dv) for the surface-derivative elements
+SF1 = [[1 / 3, 1 / 3, 1 / 3], [-1.0, 1.0, 0.0], [-1.0, 0.0, 1.0]]
+SF2 = [[0.3, 0.3, 0.4], [-0.5, 0.5, 0.0], [-0.5, 0.0, 0.5]]
+
+
+def _make_nodes(ref_locations, act_locations):
+    nodes = []
+    for ref, act in zip(ref_locations, act_locations):
+        node = eq.Node()
+        node.ref_location = ref
+        node.act_location = act
+        nodes.append(node)
+    return nodes
+
+
+def _assert_multipoint_is_sum(element_both, element_0, element_1):
+    f_both, g_both, h_both = element_both.compute_all()
+    f0, g0, h0 = element_0.compute_all()
+    f1, g1, h1 = element_1.compute_all()
+
+    # non-vacuous: each single point must actually contribute a gradient
+    assert np.any(g0 != 0.0)
+    assert np.any(g1 != 0.0)
+
+    assert_almost_equal(f_both, f0 + f1)
+    assert_almost_equal(g_both, g0 + g1)
+    assert_almost_equal(np.triu(h_both), np.triu(h0) + np.triu(h1))
+
+
+def test_point_distance_ad_accumulates_multiple_points():
+    nodes_a = _make_nodes(REF_A, ACT_A)
+    nodes_b = _make_nodes(REF_B, ACT_B)
+
+    sf_a1, sf_b1, w1 = [[0.2, 0.3, 0.5]], [[0.1, 0.6, 0.3]], 1.3
+    sf_a2, sf_b2, w2 = [[0.5, 0.1, 0.4]], [[0.25, 0.25, 0.5]], 0.7
+
+    both = eq.IgaPointDistanceAD(nodes_a, nodes_b)
+    both.add(sf_a1, sf_b1, w1)
+    both.add(sf_a2, sf_b2, w2)
+
+    e0 = eq.IgaPointDistanceAD(nodes_a, nodes_b)
+    e0.add(sf_a1, sf_b1, w1)
+    e1 = eq.IgaPointDistanceAD(nodes_a, nodes_b)
+    e1.add(sf_a2, sf_b2, w2)
+
+    _assert_multipoint_is_sum(both, e0, e1)
+
+
+def test_normal_distance_ad_accumulates_multiple_points():
+    nodes_a = _make_nodes(REF_A, ACT_A)
+    nodes_b = _make_nodes(REF_B, ACT_B)
+
+    both = eq.IgaNormalDistanceAD(nodes_a, nodes_b)
+    both.add(SF1, SF1, 1.3)
+    both.add(SF2, SF2, 0.7)
+
+    e0 = eq.IgaNormalDistanceAD(nodes_a, nodes_b)
+    e0.add(SF1, SF1, 1.3)
+    e1 = eq.IgaNormalDistanceAD(nodes_a, nodes_b)
+    e1.add(SF2, SF2, 0.7)
+
+    _assert_multipoint_is_sum(both, e0, e1)
+
+
+def test_rotation_coupling_ad_accumulates_multiple_points():
+    nodes_a = _make_nodes(REF_A, ACT_A)
+    nodes_b = _make_nodes(REF_B, ACT_B)
+
+    # axis must not be aligned with the surface normal a3, otherwise
+    # omega . axis vanishes and the coupling has no gradient.
+    axis = [1.0, 0.0, 0.0]
+
+    both = eq.IgaRotationCouplingAD(nodes_a, nodes_b)
+    both.add(SF1, SF1, axis, 1.3)
+    both.add(SF2, SF2, axis, 0.7)
+
+    e0 = eq.IgaRotationCouplingAD(nodes_a, nodes_b)
+    e0.add(SF1, SF1, axis, 1.3)
+    e1 = eq.IgaRotationCouplingAD(nodes_a, nodes_b)
+    e1.add(SF2, SF2, axis, 0.7)
+
+    _assert_multipoint_is_sum(both, e0, e1)


### PR DESCRIPTION
## Problem

`IgaPointDistanceAD`, `IgaNormalDistanceAD` and `IgaRotationCouplingAD` write the element gradient `g` and Hessian `h` with `=` **inside the loop over integration points**, while the scalar value `f` is accumulated with `+=`:

```cpp
for (const auto& [...] : m_data) {
    ...
    f += Space::f(result);          // accumulated
    g(0 + r) = result.g(...) * ...; // OVERWRITES -> only the last point survives
    h(0 + r, 0 + s) = ...;          // OVERWRITES
}
```

The `g`/`h` indices depend only on the local DOF, so every integration point writes the same slots. For an element with more than one point (multiple `add()` calls) only the **last** point's contribution remains in `g`/`h`, while `f` is the sum over all points — an inconsistent gradient/Hessian.

`IgaPointLocation`, `IgaShell3PAD` and `IgaMembrane3PAD` already accumulate with `+=`; this is a divergence in the three AD coupling elements.

`IgaNormalDistanceAD` and `IgaRotationCouplingAD` additionally never zeroed `g`/`h` (previously masked by the full overwrite).

## Fix

- `=` → `+=` for all `g`/`h` writes in the three AD objectives.
- Add the missing `g.setZero()`/`h.setZero()` to `IgaNormalDistanceAD` and `IgaRotationCouplingAD` (required once entries are accumulated; `IgaPointDistanceAD` already had it).

Single-point behaviour is unchanged (`+=` from a zeroed buffer equals the old `=`), so the existing baked single-point reference tests still pass.

## Test

New `tests/test_iga_ad_multi_point.py` uses a value-free invariant: an element with two integration points must equal the elementwise sum of two single-point elements over the same nodes, for `f`, `g` and the upper triangle of `h`.

- Before the fix: `f` matches but `g`/`h` equal only the last point's contribution (all three tests fail on the `g` assertion).
- After the fix: all three pass; full suite 46 passed.