### PR TITLE
fix: check for end iterator before dereferencing in SparseStructure lookups

### DIFF
--- a/include/eqlib/SparseStructure.h
+++ b/include/eqlib/SparseStructure.h
@@ -118,7 +118,7 @@ public: // methods
 
         const auto it = std::lower_bound(lower, upper, j);
 
-        if (*it != j || it == upper) {
+        if (it == upper || *it != j) {
             return -1;
         }
 
@@ -153,7 +153,7 @@ public: // methods
 
             const auto it = std::lower_bound(lower, upper, j);
 
-            if (*it != j || it == upper) {
+            if (it == upper || *it != j) {
                 return -1;
             }
 

--- a/tests/test_sparse_structure.py
+++ b/tests/test_sparse_structure.py
@@ -60,6 +60,22 @@ def test_csr_square(csr_square):
     assert_equal(structure.density, 7 / 16)
 
 
+def test_get_index_missing_column_past_last_row():
+    # A column that is absent and larger than every stored column of the LAST
+    # row drives the internal lower_bound to the end of the ja buffer. The C++
+    # lookup used to dereference that end iterator before checking it against
+    # the end (an out-of-bounds read on the last row; verified and fixed under
+    # AddressSanitizer). The observable contract is simply -1.
+    structure = eq.RowMajorSparseStructure(2, 4, [0, 1, 2], [0, 1])
+
+    assert_equal(structure.get_index(0, 0), 0)
+    assert_equal(structure.get_index(1, 1), 1)
+    # missing, past the end of the last row's stored columns
+    assert_equal(structure.get_index(1, 3), -1)
+    # missing in an earlier row
+    assert_equal(structure.get_index(0, 3), -1)
+
+
 def test_csr_convert_from(csr_rectangular):
     a = np.array([0, 1, 2, 3, 4, 5], float)
 


### PR DESCRIPTION
## Problem

`SparseStructure::get_index_bounded` and the non-index-map branch of `get_index` order the guard as:

```cpp
const auto it = std::lower_bound(lower, upper, j);
if (*it != j || it == upper) { return -1; }   // *it evaluated before the end check
```

When `j` is absent and larger than every stored column of a row, `lower_bound` returns `upper`. `*it` is then dereferenced **before** `it == upper` is tested. On the **last** row `upper == m_ja.end()`, so this reads one element past the `m_ja` vector — undefined behaviour.

The `|| it == upper` still makes the function return the correct `-1`, so the *result* is right; the defect is strictly the out-of-bounds read.

## Fix

Swap the operands so the end check short-circuits before the dereference:

```cpp
if (it == upper || *it != j) { return -1; }
```

Applied in both `get_index_bounded` and `get_index`.

## Verification (AddressSanitizer)

The buggy path is **not reachable from the Python API** — the bound `SparseStructure` uses `TIndexMap = true` (hash-map lookup) and `get_index_bounded` is not exposed — so a standalone ASan harness against the real header is used. Building a `SparseStructure<double, int, true, false>` with 2 rows / `ja = {0, 1}` and querying a missing column on the last row:

Before the fix:
```
==ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 4
    #0 ... SparseStructure<double,int,true,false>::get_index_bounded(...) SparseStructure.h:121
0x... is located 0 bytes after 8-byte region  (the 2-int ja buffer)
```
After the fix: no error, and lookups return the expected values (missing → -1, present → correct index).

## Test

A contract test (`tests/test_sparse_structure.py::test_get_index_missing_column_past_last_row`) guards the `-1` result for a missing column past the end of the last row. Note: through the Python bindings this exercises the index-map path, so it documents/guards the contract; the out-of-bounds read itself is covered by the ASan harness above. Full suite: 43 passed.

A permanent C++/AddressSanitizer test job would be a sensible follow-up (this bug class is invisible to the pytest suite).