### PR TITLE
fix: use consistent Voigt order for the shell reference curvature

### DIFF
--- a/include/eqlib/objectives/IgaShell3PAD.h
+++ b/include/eqlib/objectives/IgaShell3PAD.h
@@ -66,7 +66,7 @@ public: // methods
         const Vector3d ref_a3 = ref_a1.cross(ref_a2).normalized();
 
         const Vector3d ref_a(ref_a1.dot(ref_a1), ref_a2.dot(ref_a2), ref_a1.dot(ref_a2));
-        const Vector3d ref_b(ref_a1_1.dot(ref_a3), ref_a1_2.dot(ref_a3), ref_a2_2.dot(ref_a3));
+        const Vector3d ref_b(ref_a1_1.dot(ref_a3), ref_a2_2.dot(ref_a3), ref_a1_2.dot(ref_a3));
 
         const Vector3d e1 = ref_a1.normalized();
         const Vector3d e2 = (ref_a2 - ref_a2.dot(e1) * e1).normalized();

--- a/tests/test_iga_shell_3p_symmetry.py
+++ b/tests/test_iga_shell_3p_symmetry.py
@@ -1,0 +1,83 @@
+"""Independent correctness oracle for IgaShell3PAD's curvature ordering.
+
+The existing IgaShell3PAD test asserts against baked reference values produced
+by the element itself, and its reference configuration is flat (the reference
+curvature b vanishes), so it cannot reveal a wrong curvature. A
+finite-difference check of g against f is no help either: the AD differentiates
+whatever energy expression is written, so g stays consistent with f even if the
+expression is wrong.
+
+This test uses a value-level physical invariant on a *curved* reference: for an
+isotropic material the Kirchhoff-Love shell energy is invariant under renaming
+the two parametric directions (u1 <-> u2). Relabelling only permutes the
+shape-function rows (1<->2 for the first derivatives, 3<->5 for the second
+derivatives); the energy must be unchanged.
+
+The membrane metric and the transformation matrix are built in Voigt order
+[11, 22, 12], and act_b uses that order, so the reference curvature ref_b must
+use it too. If ref_b instead uses [11, 12, 22], the relabel symmetry breaks on
+a curved reference.
+"""
+
+import eqlib as eq
+import numpy as np
+import pytest
+from numpy.testing import assert_almost_equal
+
+if __name__ == "__main__":
+    import os
+    import sys
+
+    print(f"pid: {os.getpid()}")
+    pytest.main(sys.argv)
+
+
+# 6x6 identity shape functions: row k selects node k, so rows 1..5 map directly
+# to a1, a2, a1_1, a1_2, a2_2 of nodes 1..5 (row 0 = values, unused by the shell).
+SHAPE_FUNCTIONS = np.eye(6)
+
+# Curved reference: the reference second-derivative vectors have a normal
+# component with distinct b11=0.5, b22=0.9, b12=0.2, so the ref_b ordering
+# actually matters (a flat reference would hide the bug).
+REF_LOCATIONS = [
+    [0.0, 0.0, 0.0],  # node 0 (unused by geometry)
+    [2.0, 0.0, 0.0],  # a1
+    [0.0, 3.0, 0.0],  # a2
+    [0.0, 0.0, 0.5],  # a1_1
+    [0.0, 0.0, 0.2],  # a1_2
+    [0.0, 0.0, 0.9],  # a2_2
+]
+ACT_LOCATIONS = [
+    [0.0, 0.0, 0.0],
+    [2.1, 0.0, 0.0],
+    [0.0, 3.05, 0.0],
+    [0.0, 0.0, 0.6],
+    [0.0, 0.0, 0.25],
+    [0.0, 0.0, 1.0],
+]
+
+# relabel u1 <-> u2: rows [val, d/du1, d/du2, d2/du1^2, d2/du1du2, d2/du2^2]
+PERM = [0, 2, 1, 5, 4, 3]
+
+
+def _shell_energy(shape_functions):
+    nodes = []
+    for ref, act in zip(REF_LOCATIONS, ACT_LOCATIONS):
+        node = eq.Node()
+        node.ref_location = ref
+        node.act_location = act
+        nodes.append(node)
+
+    element = eq.IgaShell3PAD(nodes, 1, 100, 0)  # thickness=1, E=100, nu=0 (isotropic)
+    element.add(np.asarray(shape_functions), 1.5)
+    return element.compute_all()[0]
+
+
+def test_shell_energy_invariant_under_parametric_relabel():
+    f_orig = _shell_energy(SHAPE_FUNCTIONS)
+    f_swapped = _shell_energy(SHAPE_FUNCTIONS[PERM])
+
+    # non-vacuous: the curved reference must carry bending energy
+    assert abs(f_orig) > 1e-6
+
+    assert_almost_equal(f_swapped, f_orig)


### PR DESCRIPTION
## Problem

`IgaShell3PAD` builds the membrane metric (`ref_a`/`act_a`) and the strain transformation matrix `T` in Voigt order **[11, 22, 12]**, and the actual curvature uses the same order:

```cpp
act_b(act_a1_1.dot(act_a3), act_a2_2.dot(act_a3), act_a1_2.dot(act_a3));   // [11, 22, 12]
```

But the reference curvature built in `add()` used **[11, 12, 22]**:

```cpp
ref_b(ref_a1_1.dot(ref_a3), ref_a1_2.dot(ref_a3), ref_a2_2.dot(ref_a3));   // [11, 12, 22]  <-- swapped
```

`kap = T * (act_b - ref_b)` applies the same `[11, 22, 12]` transform to both operands, so the mismatched ordering subtracts the `b12` and `b22` components across different slots — a wrong bending strain whenever the **reference surface is curved** (`ref_b != 0`).

Flat references (`ref_b == 0`) and the membrane element (`IgaMembrane3PAD`, whose `ref_a`/`act_a` are consistently `[11, 22, 12]`) are unaffected. This is why the existing baked reference test — a flat patch — does not change.

## Fix

Reorder `ref_b` to `[11, 22, 12]` to match `act_b` and the transformation:

```cpp
ref_b(ref_a1_1.dot(ref_a3), ref_a2_2.dot(ref_a3), ref_a1_2.dot(ref_a3));
```

## Why the usual tests can't catch this

- The baked `test_iga_shell_3p_ad` asserts values produced by the element itself, and its reference is flat — the bug is invisible there.
- A finite-difference check of `g` vs `f` cannot catch it either: the AD differentiates whatever energy expression is written, so `g` stays consistent with `f` even when that expression is wrong.

## Test

`tests/test_iga_shell_3p_symmetry.py` uses a value-level physical invariant on a **curved** reference: for an isotropic material the shell energy must be invariant under relabelling the parametric directions `u1 <-> u2` (which only permutes the shape-function rows). 

- Before the fix: `f_orig = 0.4182` vs `f_swapped = 0.3031` → fails.
- After the fix: equal → passes.

Cross-checked independently against a numpy reference implementation using the consistent `[11, 22, 12]` ordering (element `f` moves from `0.4182` (matches the buggy ordering) to `0.2237` (matches the reference)). Full suite: 44 passed, existing shell baseline unchanged.

## Impact

Kirchhoff-Love shells with a **curved reference geometry** previously produced an incorrect energy, gradient and Hessian. Flat references and membranes were not affected.